### PR TITLE
Fix double brackets in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ from htlogicalgates import *
 circ = taylor_logical_gate("4_2_2", "circular", "H 0", 2)
 ```
 
-Here, we construct a logical gate for the $\llbracket4,2,2\rrbracket$-code, as indicated by the argument `"4_2_2"`. We use a `"circular"`-connectivity and search a circuit implementation for `"H 0"`, the Hadamard gate on logical qubit 0. The ansatz consists of `2` controlled-Z gate layers.
+Here, we construct a logical gate for the $⟦4,2,2⟧$-code, as indicated by the argument `"4_2_2"`. We use a `"circular"`-connectivity and search a circuit implementation for `"H 0"`, the Hadamard gate on logical qubit 0. The ansatz consists of `2` controlled-Z gate layers.


### PR DESCRIPTION
Using the unicode points `U+27E6` and `U+27E7`