### PR TITLE
[improve] tutorial

### DIFF
--- a/doc/tutorial.ipynb
+++ b/doc/tutorial.ipynb
@@ -56,29 +56,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'8_3_2': '[[8,3,2]] hypercube and color code.',\n",
-       " '4_2_2': '[[4,2,2]] iceberg and color code.',\n",
-       " '12_2_3': '[[12,2,3]] twisted toric-24 code.',\n",
-       " 'trivial': 'The trivial [[n,n,1]] code.'}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "stab_code = htlg.StabilizerCode(\"4_2_2\")\n",
-    "conn = htlg.Connectivity(\"circular\", num_qubits=4)\n",
-    "log_gate = htlg.Circuit(2)\n",
-    "log_gate.h(0)\n",
-    "htlg.available_connectivities\n"
+    "connectivity = htlg.Connectivity(\"circular\", num_qubits=4)\n",
+    "logical_gate = htlg.Circuit(2)\n",
+    "logical_gate.h(0)"
    ]
   },
   {
@@ -100,11 +85,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "circ, status = htlg.tailor_logical_gate(stab_code, conn, log_gate, num_cz_layers=2)"
+    "circ, status = htlg.tailor_logical_gate(stab_code, connectivity, logical_gate, num_cz_layers=2)"
    ]
   },
   {
@@ -143,24 +128,22 @@
       "Status: \"Optimal\"\n",
       "\n",
       "Circuit:\n",
-      "Z 2\n",
-      "C_XYZ 0\n",
-      "CZ 0 1\n",
+      "Z 1\n",
+      "C_XYZ 3\n",
       "CZ 1 2\n",
-      "C_XYZ 1\n",
-      "CZ 0 1\n",
+      "CZ 2 3\n",
+      "C_XYZ 2\n",
       "CZ 1 2\n",
-      "C_ZYX 0\n",
-      "S 1\n",
+      "CZ 2 3\n",
+      "S 2\n",
+      "C_ZYX 3\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "print(f'Status: \"{status}\"')\n",
-    "print()\n",
-    "print(\"Circuit:\")\n",
-    "print(circ)"
+    "print(f'Status: \"{status}\"\\n')\n",
+    "print(f'Circuit:\\n{circ}')"
    ]
   },
   {
@@ -279,14 +262,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
-    "arr = np.array([[0, 1, 0, 0], [1, 0, 1, 0], [0, 1, 0, 1], [0, 0, 1, 0]])\n",
-    "con = htlg.Connectivity(arr)"
+    "adjacency_matrix = np.array([\n",
+    "    [0, 1, 0, 0],\n",
+    "    [1, 0, 1, 0],\n",
+    "    [0, 1, 0, 1],\n",
+    "    [0, 0, 1, 0]\n",
+    "])\n",
+    "connectivity = htlg.Connectivity(adjacency_matrix)"
    ]
   },
   {
@@ -305,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This PR addresses #43 and rewrites large parts of the tutorial Jupyter notebook. 

Changes include
- Making the descriptions more concise
- Reformulations and grammar fixes
- Removal of redundant passages
- Writing out variable names
- Using the (in my opinion) more intuitive `circuit.h(0)` 
- Typo fixes